### PR TITLE
Proof of concept for reducing compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ assert_eq!(cat, ProductCategory::AnimalsAndPetSuppliesLiveAnimals);
 ### Get the number representation of the product category
 ```rust
 use google_taxonomy::ProductCategory;
-assert_eq!(ProductCategory::AnimalsAndPetSuppliesLiveAnimals as u32, 3237);
+assert_eq!(ProductCategory::AnimalsAndPetSuppliesLiveAnimals.id(), 3237);
 ```
 
 ### Get the name of a product category

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn casts_to_category_id() {
         assert_eq!(
-            ProductCategory::AnimalsAndPetSuppliesLiveAnimals as u32,
+            ProductCategory::AnimalsAndPetSuppliesLiveAnimals.id,
             3237
         );
     }
@@ -280,6 +280,18 @@ mod tests {
             ProductCategory::from_str("Some Nonexistent Category"),
             Err(Error::NameNotFound)
         );
+    }
+
+    #[test]
+    fn do_the_thing() {
+        let id = 151515;
+        let mut foo = None;
+        for var in &ProductCategory::ALL {
+            if var.id == id {
+                foo = Some(var);
+            }
+        }
+        assert_eq!(foo, None);
     }
 }
 


### PR DESCRIPTION
This is hacked together and a little messy (can't spend any more time on this), but this takes a release build from 40s to 2s on my machine. The downsides are that now `ProductCategory` is a bit beefy (like 40 bytes, so I made it not `Copy`.) and the runtime performance of `from_name` and `from_id` might be worse. You could probably improve both of these by being a bit smarter though.