### PR TITLE
Reduce complex code generated by build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ assert_eq!(cat, ProductCategory::AnimalsAndPetSuppliesLiveAnimals);
 ### Get the number representation of the product category
 ```rust
 use google_taxonomy::ProductCategory;
-assert_eq!(ProductCategory::AnimalsAndPetSuppliesLiveAnimals as u32, 3237);
+assert_eq!(ProductCategory::AnimalsAndPetSuppliesLiveAnimals.id(), 3237);
 ```
 
 ### Get the name of a product category


### PR DESCRIPTION
Looking at #6 , it seems we've taken similar approaches to solving the compile time problem. I think we landed on the right fix of sidestepping the large amount of code handed to LLVM 😉

My implementation ended up using the same list of ids we search to cache the data, ultimately making the `ProductCategory` type half the size, and very likely significantly speeding up category lookups.

I also took the chance to simplify the generated code and move what I could into `lib.rs`. I think it makes it easier to understand what's going on.